### PR TITLE
Enable graceful shutdown

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,7 +1,6 @@
 # Example .env file for production
 # PostOwl settings
 DB_PATH="./data/db.sqlite3"
-BODY_SIZE_LIMIT="0"
 ORIGIN="https://yourapp.fly.dev"
 ADMIN_PASSWORD="your-secret-password"
 ADMIN_NAME="Your Name"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ RUN apt update -qq && \
 
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/build /app/build
+COPY --from=builder /app/.env.production /app/build
 COPY --from=builder /app/package.json /app
-COPY --from=builder /app/scripts/fly-start.sh /app
 COPY --from=builder /app/scripts/schema.sql /app
-COPY --from=builder /app/.env.production /app/build/
+COPY --from=builder /app/scripts/start-fly.sh /app
+COPY --from=builder /app/scripts/start-app.js /app
 WORKDIR /app
 ENV NODE_ENV production
 

--- a/fly.toml.example
+++ b/fly.toml.example
@@ -29,6 +29,6 @@ primary_region = "iad"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = false
+  auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0

--- a/fly.toml.example
+++ b/fly.toml.example
@@ -16,7 +16,7 @@ primary_region = "iad"
 
 # Override the CMD set in Dockerfile so we can migrate the SQLite database
 [experimental]
-  cmd = ["fly-start.sh"]
+  cmd = ["start-fly.sh"]
   entrypoint = ["sh"]
 
 [env]

--- a/scripts/start-app.js
+++ b/scripts/start-app.js
@@ -1,0 +1,10 @@
+import {server as app} from "./build/index.js"
+
+function shutdownGracefully() {
+    console.log("Server doing graceful shutdown");
+    app.server.close();
+}
+
+// Shutdown gracefully when fly machine auto stops
+process.on("SIGINT", shutdownGracefully);
+process.on("SIGTERM", shutdownGracefully);

--- a/scripts/start-app.js
+++ b/scripts/start-app.js
@@ -1,10 +1,10 @@
-import {server as app} from "./build/index.js"
+import { server as app } from "./build/index.js"
 
-function shutdownGracefully() {
-    console.log("Server doing graceful shutdown");
-    app.server.close();
+function shutdownServer() {
+  console.log("Server doing graceful shutdown");
+  app.server.close();
 }
 
 // Shutdown gracefully when fly machine auto stops
-process.on("SIGINT", shutdownGracefully);
-process.on("SIGTERM", shutdownGracefully);
+process.on("SIGINT", shutdownServer);
+process.on("SIGTERM", shutdownServer);

--- a/scripts/start-fly.sh
+++ b/scripts/start-fly.sh
@@ -13,4 +13,4 @@ then
 fi
 
 sqlite3 data/db.sqlite3 < schema.sql
-node -r dotenv/config build
+node -r dotenv/config ./start-app.js

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -6,11 +6,23 @@ import { DB_PATH, ADMIN_NAME, ADMIN_PASSWORD, ORIGIN } from '$env/static/private
 import sendMail from '$lib/sendMail';
 import { Blob } from 'node:buffer';
 
-const db = new Database(DB_PATH, {
+
+/**
+ * Database setup
+ */
+
+let db = global.db = new Database(DB_PATH, {
   // verbose: console.log
 });
 db.pragma('journal_mode = WAL');
 db.pragma('case_sensitive_like = false');
+
+function shutDownSQLite() {
+  console.log("SQLite doing graceful shutdown");
+  db.close();
+}
+process.on("SIGINT", shutDownSQLite);
+process.on("SIGTERM", shutDownSQLite);
 
 /**
  * Creates a post
@@ -38,7 +50,6 @@ export async function createPost(
     if (postExists) {
       slug = slug + '-' + nanoid();
     }
-
     const post = db
       .prepare(
         'INSERT INTO posts (slug, title, content, teaser, teaser_image, is_public, created_at) values(?, ?, ?, ?, ?, ?, ?) RETURNING slug, post_id, created_at'

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -11,7 +11,7 @@ import { Blob } from 'node:buffer';
  * Database setup
  */
 
-let db = global.db = new Database(DB_PATH, {
+let db = new Database(DB_PATH, {
   // verbose: console.log
 });
 db.pragma('journal_mode = WAL');


### PR DESCRIPTION
When Fly machines auto stop we should gracefully shutdown the app: https://kit.svelte.dev/docs/adapter-node#troubleshooting-is-there-a-hook-for-cleaning-up-before-the-server-exits