### PR TITLE
feat(posts): add bookmark component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ SMTP_SERVER="localhost"
 SMTP_PORT="1025"
 SMTP_USERNAME="postmaster@localhost" # can be whatever you want in dev
 SMTP_PASSWORD="password" # can be whatever you want in dev
+
+# Bookmark settings
+# Tracks reading progress and shows "continue reading" button
+PUBLIC_BOOKMARK_MODE="enabled" # Options "enabled", "mobile", "disabled"

--- a/src/lib/components/Bookmark.svelte
+++ b/src/lib/components/Bookmark.svelte
@@ -1,0 +1,134 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { fade } from 'svelte/transition';
+  import { env } from '$env/dynamic/public';
+
+  export let slug;
+  export let editable = false;
+  
+  let showButton = false;
+  let savedPosition = 0;
+  let scrollTimer;
+  let lastScrollPosition = 0;
+  let isMobile = false;
+  
+  const STORAGE_KEY = `postowl-bookmark-${slug}`;
+  const SCROLL_THRESHOLD = 100;
+  const bookmarkMode = env.PUBLIC_BOOKMARK_MODE ?? 'disabled';
+  
+  function shouldShowBookmark() {
+    if (bookmarkMode === 'disabled') return false;
+    if (bookmarkMode === 'mobile' && !isMobile) return false;
+    return true;
+  }
+  
+  function checkIfMobile() {
+    if (!browser) return;
+    isMobile = window.innerWidth < 640; // Using Tailwind's sm breakpoint
+  }
+  
+  function loadBookmark() {
+    if (!browser || !shouldShowBookmark()) return;
+    
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      savedPosition = parseInt(saved, 10);
+      const currentScroll = window.scrollY || window.pageYOffset;
+      
+      if (savedPosition > currentScroll + SCROLL_THRESHOLD) {
+        showButton = true;
+      }
+    }
+  }
+  
+  function saveBookmark() {
+    if (!browser) return;
+    
+    const currentScroll = window.scrollY || window.pageYOffset;
+    const docHeight = document.documentElement.scrollHeight;
+    const windowHeight = window.innerHeight;
+    
+    if (currentScroll > 100 && currentScroll < docHeight - windowHeight - 100) {
+      localStorage.setItem(STORAGE_KEY, currentScroll.toString());
+      lastScrollPosition = currentScroll;
+    }
+  }
+  
+  function handleScroll() {
+    if (!browser || !shouldShowBookmark()) return;
+    
+    clearTimeout(scrollTimer);
+    
+    const currentScroll = window.scrollY || window.pageYOffset;
+    
+    if (savedPosition > 0) {
+      if (currentScroll >= savedPosition - SCROLL_THRESHOLD) {
+        showButton = false;
+      } else if (currentScroll < savedPosition - SCROLL_THRESHOLD * 2) {
+        showButton = true;
+      }
+    }
+    
+    scrollTimer = setTimeout(() => {
+      saveBookmark();
+    }, 2000);
+  }
+  
+  function scrollToBookmark() {
+    if (!browser || !savedPosition) return;
+    
+    window.scrollTo({
+      top: savedPosition,
+      behavior: 'smooth'
+    });
+    
+    setTimeout(() => {
+      showButton = false;
+    }, 500);
+  }
+  
+  function handleResize() {
+    checkIfMobile();
+    if (!shouldShowBookmark() && showButton) {
+      showButton = false;
+    } else if (shouldShowBookmark()) {
+      loadBookmark();
+    }
+  }
+  
+  onMount(() => {
+    if (!browser) return;
+    
+    checkIfMobile();
+    
+    if (shouldShowBookmark()) {
+      loadBookmark();
+      window.addEventListener('scroll', handleScroll, { passive: true });
+      handleScroll();
+    }
+    
+    window.addEventListener('resize', handleResize);
+  });
+  
+  onDestroy(() => {
+    if (!browser) return;
+    
+    window.removeEventListener('scroll', handleScroll);
+    window.removeEventListener('resize', handleResize);
+    clearTimeout(scrollTimer);
+  });
+</script>
+
+{#if showButton}
+  <button
+    transition:fade={{ duration: 300 }}
+    on:click={scrollToBookmark}
+    class="fixed bottom-8 left-1/2 -translate-x-1/2 sm:left-auto sm:translate-x-0 sm:right-8 bg-black hover:bg-gray-800 text-white px-4 py-2 rounded-full shadow-lg transition-all duration-300 transform hover:scale-105 z-50 flex items-center gap-2"
+    aria-label="Continue reading from where you left off"
+  >
+    <span class="text-lg">↓</span>
+    {editable ? 'continue editing' : 'continue reading'}
+  </button>
+{/if}
+

--- a/src/routes/posts/[slug]/+page.svelte
+++ b/src/routes/posts/[slug]/+page.svelte
@@ -8,6 +8,7 @@
   import Post from '$lib/components/Post.svelte';
   import NotEditable from '$lib/components/NotEditable.svelte';
   import RecipientsSelector from '$lib/components/RecipientsSelector.svelte';
+  import Bookmark from '$lib/components/Bookmark.svelte';
 
   export let data;
   let editable, title, content, created_at, teaser_image, teaser, is_public, recipients;
@@ -122,6 +123,8 @@
 {/if}
 
 <Post bind:title bind:content bind:created_at {editable} />
+
+<Bookmark slug={data.slug} {editable} />
 
 <NotEditable {editable}>
   <div class="text-center max-w-screen-sm mx-auto px-6 py-12 sm:py-16">


### PR DESCRIPTION
Hey, I know you want to keep this project minimal, but this is a great addition for users who plan to publish long posts. You can set the bookmark button behavior in the .env settings to enable it / enable it only on mobile. It provides a convenient way to continue reading / editing where the user left off by storing the scroll position in the browser's localStorage. Looking forward to your feedback!

## Changes
- Added new `Bookmark.svelte` component with scroll tracking logic
- Integrated bookmark into post pages
- Added configuration option to `.env.example`